### PR TITLE
fix: improve wordbreak

### DIFF
--- a/src/components/Content.astro
+++ b/src/components/Content.astro
@@ -4,6 +4,7 @@
       A domain name can be registered with up to 63 characters, so I registered <a
         href="https://loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.ong"
         title="Long"
+        class="break-all"
         >loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.ong</a
       >.
       <br />
@@ -35,6 +36,9 @@
 
   p {
     margin: 0.5rem 0;
+  }
+
+  .break-all {
     word-break: break-all;
   }
 </style>

--- a/src/components/Display.astro
+++ b/src/components/Display.astro
@@ -29,7 +29,7 @@
   }
 
   span {
-    word-break: break-all;
+    word-break: break-word;
   }
 
   a {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,7 +4,7 @@ import config from "../config";
 
 <header>
   <a href="/" title={config.title}><h1>{config.title}</h1></a>
-  <p>
+  <p class="break-all">
     Make your URL
     looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooonger
   </p>
@@ -43,8 +43,11 @@ import config from "../config";
 
   p {
     text-align: center;
-    word-break: break-all;
     margin: 0;
+  }
+
+  .break-all {
+    word-break: break-all;
   }
 
   ul {

--- a/src/components/Tool.astro
+++ b/src/components/Tool.astro
@@ -9,7 +9,7 @@
   </fieldset>
   <fieldset>
     <legend>Long URL</legend>
-    <textarea id="long-url" rows="6" readonly></textarea>
+    <textarea id="long-url" rows="6" readonly class="break-all"></textarea>
     <button id="open-url">Open URL</button>
     <button id="copy-url">Copy URL</button>
   </fieldset>
@@ -46,6 +46,10 @@
 
   button {
     margin-top: 0;
+  }
+
+  .break-all {
+    word-break: break-all;
   }
 </style>
 


### PR DESCRIPTION
Should only do `break-all` in the places that contains the url

Before:

<img width="1003" alt="Screenshot 2024-06-17 at 15 18 24" src="https://github.com/ccbikai/loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.ong/assets/11247099/6f62ddc0-475f-497e-a709-71d87807f0bc">


After:

<img width="891" alt="Screenshot 2024-06-17 at 15 18 35" src="https://github.com/ccbikai/loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.ong/assets/11247099/ae9d5615-89de-4cd4-89a7-f5b75352bfe0">
